### PR TITLE
Upgrade to caracat v1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,26 +155,18 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "caracat"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd97c843046831972f506f68d6e63782d5cb0540f50882da734ae947c7b701a"
+checksum = "20866868f7345fdcf504a36550c98886a834e9740e12d02df7c38ff4082cc831"
 dependencies = [
  "anyhow",
- "chrono",
  "circular-queue",
- "csv",
- "env_logger",
- "hex",
- "hyperloglog",
  "ip_network",
  "ip_network_table",
- "ip_network_table-deps-treebitmap",
  "log",
  "pcap",
  "pnet",
- "rand",
  "serde",
- "strum",
 ]
 
 [[package]]
@@ -427,12 +419,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +656,7 @@ dependencies = [
  "clap-verbosity-flag",
  "csv",
  "env_logger",
+ "hyperloglog",
  "log",
  "pcap",
  "rdkafka",
@@ -965,12 +952,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustversion"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,28 +1055,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "sval"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,13 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.95"
-caracat = "1.2.0"
+caracat = "1.3.0"
 chrono = "0.4.39"
 clap = { version = "4.5.20", features = ["derive"] }
 clap-verbosity-flag = "3.0.0"
 csv = "1.3.1"
 env_logger = "0.11.5"
+hyperloglog = "1.0.2"
 log = "0.4.22"
 pcap = "2.2.0"
 rdkafka = { version = "0.37.0" }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,27 +1,61 @@
 use anyhow::Result;
-use caracat::high_level::Config;
 use caracat::models::Probe;
+use caracat::rate_limiter::RateLimitingMethod;
 use log::{info, warn};
 use rdkafka::message::BorrowedMessage;
 use rdkafka::message::{Headers, Message};
 use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::Ipv6Addr;
 use std::time::Duration;
 use tokio::task;
 
 use crate::prober::probe;
 
+/// Probing configuration.
+#[derive(Debug)]
+pub struct Config {
+    /// Number of probes to send before calling the rate limiter.
+    pub batch_size: u64,
+    /// Identifier encoded in the probes (random by default).
+    pub instance_id: u16,
+    /// Whether to actually send the probes on the network or not.
+    pub dry_run: bool,
+    /// Do not send probes with ttl < min_ttl.
+    pub min_ttl: Option<u8>,
+    /// Do not send probes with ttl > max_ttl.
+    pub max_ttl: Option<u8>,
+    /// Check that replies match valid probes.
+    pub integrity_check: bool,
+    /// Interface from which to send the packets.
+    pub interface: String,
+    /// Source IPv4 address
+    pub src_ipv4_addr: Option<Ipv4Addr>,
+    /// Source IPv6 address
+    pub src_ipv6_addr: Option<Ipv6Addr>,
+    /// Maximum number of probes to send (unlimited by default).
+    pub max_probes: Option<u64>,
+    /// Number of packets to send per probe.
+    pub packets: u64,
+    /// Probing rate in packets per second.
+    pub probing_rate: u64,
+    /// Method to use to limit the packets rate.
+    pub rate_limiting_method: RateLimitingMethod,
+    /// Time in seconds to wait after sending the probes to stop the receiver.
+    pub receiver_wait_time: Duration,
+}
+
 fn create_config() -> Config {
     Config {
-        allowed_prefixes_file: None,
-        blocked_prefixes_file: None,
         batch_size: 128,
         dry_run: false,
-        extra_string: None,
         min_ttl: None,
         max_ttl: None,
         integrity_check: true,
         instance_id: 0,
         interface: caracat::utilities::get_default_interface(),
+        src_ipv4_addr: None,
+        src_ipv6_addr: None,
         max_probes: None,
         packets: 1,
         probing_rate: 100,

--- a/src/prober.rs
+++ b/src/prober.rs
@@ -1,6 +1,9 @@
 //! High-level interface for capturing replies.
 use anyhow::Result;
+use hyperloglog::HyperLogLog;
 
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::io::{stdout, Write};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -9,13 +12,11 @@ use std::thread::JoinHandle;
 
 use log::{error, info, trace};
 
-use caracat::high_level::{Config, ReceiveStatistics, SendLoop, SendStatistics};
-use caracat::logger::StatisticsLogger;
+use crate::handler::Config;
 use caracat::models::Probe;
 use caracat::rate_limiter::RateLimiter;
 use caracat::receiver::Receiver;
 use caracat::sender::Sender;
-use caracat::utilities::prefix_filter_from_file;
 
 /// Send probes from an iterator.
 pub fn probe<T: Iterator<Item = Probe>>(
@@ -23,33 +24,20 @@ pub fn probe<T: Iterator<Item = Probe>>(
     probes: T,
     csv_output: Option<String>,
 ) -> Result<(SendStatistics, ReceiveStatistics)> {
-    info!("{}", config);
-
-    let allowed_prefixes = match config.allowed_prefixes_file {
-        None => None,
-        Some(path) => Some(prefix_filter_from_file(&path)?),
-    };
-
-    let blocked_prefixes = match config.blocked_prefixes_file {
-        None => None,
-        Some(path) => Some(prefix_filter_from_file(&path)?),
-    };
+    info!("{:?}", config);
 
     let rate_limiter = RateLimiter::new(
         config.probing_rate,
         config.batch_size,
         config.rate_limiting_method,
     );
-    let rate_statistics = rate_limiter.statistics().clone();
 
     let receiver = ReceiveLoop::new(
         config.interface.clone(),
         config.instance_id,
-        config.extra_string,
         config.integrity_check,
         csv_output,
     );
-    let receiver_statistics = receiver.statistics().clone();
 
     let mut prober = SendLoop::new(
         config.batch_size,
@@ -58,14 +46,15 @@ pub fn probe<T: Iterator<Item = Probe>>(
         config.max_ttl,
         config.max_probes,
         config.packets,
-        allowed_prefixes,
-        blocked_prefixes,
         rate_limiter,
-        Sender::new(&config.interface, config.instance_id, config.dry_run)?,
+        Sender::new(
+            &config.interface,
+            None,
+            None,
+            config.instance_id,
+            config.dry_run,
+        )?,
     );
-    let prober_statistics = prober.statistics().clone();
-
-    let logger = StatisticsLogger::new(prober_statistics, rate_statistics, receiver_statistics);
 
     prober.probe(probes)?;
     info!("Waiting {:?} for replies...", config.receiver_wait_time);
@@ -76,7 +65,6 @@ pub fn probe<T: Iterator<Item = Probe>>(
     let final_receiver_statistics = receiver.statistics().lock().unwrap().clone();
 
     receiver.stop();
-    logger.stop();
 
     Ok((final_prober_statistics, final_receiver_statistics))
 }
@@ -93,7 +81,6 @@ impl ReceiveLoop {
     pub fn new(
         interface: String,
         instance_id: u16,
-        extra_string: Option<String>,
         integrity_check: bool,
         output_csv: Option<String>,
     ) -> Self {
@@ -131,8 +118,8 @@ impl ReceiveLoop {
                 statistics.pcap_dropped = pcap_statistics.dropped;
                 statistics.pcap_if_dropped = pcap_statistics.if_dropped;
                 match result {
-                    Ok(mut reply) => {
-                        trace!("{}", reply);
+                    Ok(reply) => {
+                        trace!("{:?}", reply);
                         statistics.received += 1;
                         if integrity_check && reply.is_valid(instance_id) {
                             statistics
@@ -143,7 +130,6 @@ impl ReceiveLoop {
                                     .icmp_messages_excl_dest
                                     .insert(&reply.reply_src_addr);
                             }
-                            reply.extra = extra_string.clone();
                             csv_writer.serialize(reply).unwrap();
                             // TODO: Write round column.
                             // TODO: Compare output with caracal (capture timestamp resolution?)
@@ -188,5 +174,165 @@ impl ReceiveLoop {
 
     pub fn statistics(&self) -> &Arc<Mutex<ReceiveStatistics>> {
         &self.statistics
+    }
+}
+
+pub struct SendLoop {
+    batch_size: u64,
+    instance_id: u16,
+    min_ttl: Option<u8>,
+    max_ttl: Option<u8>,
+    max_probes: Option<u64>,
+    packets: u64,
+    rate_limiter: RateLimiter,
+    sender: Sender,
+    statistics: Arc<Mutex<SendStatistics>>,
+}
+
+impl SendLoop {
+    pub fn new(
+        batch_size: u64,
+        instance_id: u16,
+        min_ttl: Option<u8>,
+        max_ttl: Option<u8>,
+        max_probes: Option<u64>,
+        packets: u64,
+        rate_limiter: RateLimiter,
+        sender: Sender,
+    ) -> Self {
+        let statistics = Arc::new(Mutex::new(SendStatistics::default()));
+        SendLoop {
+            batch_size,
+            instance_id,
+            min_ttl,
+            max_ttl,
+            max_probes,
+            packets,
+            rate_limiter,
+            sender,
+            statistics,
+        }
+    }
+
+    pub fn probe<T: Iterator<Item = Probe>>(&mut self, probes: T) -> Result<()> {
+        for probe in probes {
+            let mut statistics = self.statistics.lock().unwrap();
+            statistics.read += 1;
+
+            if let Some(ttl) = self.min_ttl {
+                if probe.ttl < ttl {
+                    trace!("{:?} filter=ttl_too_low", probe);
+                    statistics.filtered_low_ttl += 1;
+                    continue;
+                }
+            }
+
+            if let Some(ttl) = self.max_ttl {
+                if probe.ttl > ttl {
+                    trace!("{:?} filter=ttl_too_high", probe);
+                    statistics.filtered_high_ttl += 1;
+                    continue;
+                }
+            }
+
+            for i in 0..self.packets {
+                trace!(
+                    "{:?} id={} packet={}",
+                    probe,
+                    probe.checksum(self.instance_id),
+                    i + 1
+                );
+                match self.sender.send(&probe) {
+                    Ok(_) => statistics.sent += 1,
+                    Err(error) => {
+                        statistics.failed += 1;
+                        error!("{}", error);
+                    }
+                }
+                // Rate limit every `batch_size` packets sent.
+                if (statistics.sent + statistics.failed) % self.batch_size == 0 {
+                    self.rate_limiter.wait();
+                }
+            }
+
+            if let Some(max_probes) = self.max_probes {
+                if statistics.sent >= max_probes {
+                    info!("max_probes reached, exiting...");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn statistics(&self) -> &Arc<Mutex<SendStatistics>> {
+        &self.statistics
+    }
+}
+
+
+#[derive(Clone, Debug)]
+pub struct ReceiveStatistics {
+    /// Number of packets received.
+    pub pcap_received: u32,
+    /// Number of packets dropped because there was no room in the operating system's buffer when
+    /// they arrived, because packets weren't being read fast enough.
+    pub pcap_dropped: u32,
+    /// Number of packets dropped by the network interface or its driver.
+    pub pcap_if_dropped: u32,
+    pub received: u64,
+    pub received_invalid: u64,
+    pub icmp_messages_incl_dest: HyperLogLog,
+    pub icmp_messages_excl_dest: HyperLogLog,
+}
+
+impl Default for ReceiveStatistics {
+    fn default() -> Self {
+        Self {
+            pcap_received: 0,
+            pcap_dropped: 0,
+            pcap_if_dropped: 0,
+            received: 0,
+            received_invalid: 0,
+            icmp_messages_incl_dest: HyperLogLog::new(0.001),
+            icmp_messages_excl_dest: HyperLogLog::new(0.001),
+        }
+    }
+}
+
+impl Display for ReceiveStatistics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "pcap_received={}", self.pcap_received)?;
+        write!(f, " pcap_dropped={}", self.pcap_dropped)?;
+        write!(f, " pcap_interface_dropped={}", self.pcap_if_dropped)?;
+        write!(f, " packets_received={}", self.received)?;
+        write!(f, " packets_received_invalid={}", self.received_invalid,)?;
+        write!(
+            f,
+            " icmp_distinct_incl_dest={}",
+            self.icmp_messages_incl_dest.len().trunc(),
+        )?;
+        write!(
+            f,
+            " icmp_distinct_excl_dest={}",
+            self.icmp_messages_excl_dest.len().trunc(),
+        )
+    }
+}
+
+#[derive(Copy, Clone, Default, Debug)]
+pub struct SendStatistics {
+    pub read: u64,
+    pub sent: u64,
+    pub failed: u64,
+    pub filtered_low_ttl: u64,
+    pub filtered_high_ttl: u64,
+}
+
+impl Display for SendStatistics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "probes_read={} packets_sent={} packets_failed={} filtered_low_ttl={} filtered_high_ttl={}",
+               self.read, self.sent, self.failed, self.filtered_low_ttl, self.filtered_high_ttl)
     }
 }


### PR DESCRIPTION
- Addition of source IPv4/v6 address setting (currently set to `None`)
- Removal of high-level interface
  - Handled by copying relevant structs (Config, ReceiveLoop, ReceiveStatistics, SendStatistics) into Osiris.

The only functional difference is the removal of allow/blocklists. This should be re-implemented in Osiris if needed.